### PR TITLE
Pass status key placeholder to Redis scripts and fix KEYS ordering for trim mode

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -1,40 +1,38 @@
 package timebox
 
 const (
-	_appendAndProjectStatus = `
-		local function appendAndProjectStatus(statusKeyMin, statusKey)
-			local statusEnabled = #KEYS > statusKeyMin
-			local chunkSize = 128
-			local lastEventIdx = #ARGV
-			if statusEnabled then
-				lastEventIdx = lastEventIdx - 2
-			end
-			local startIdx = 2
+	_appendAndProjectStatus_ = `
+		local statusEnabled = KEYS[2] ~= ""
+		local chunkSize = 128
+		local lastEventIdx = #ARGV
+		if statusEnabled then
+			lastEventIdx = lastEventIdx - 2
+		end
+		local startIdx = 2
 
-			while startIdx <= lastEventIdx do
-				local endIdx = math.min(startIdx + chunkSize - 1, lastEventIdx)
-				local chunk = {}
-				for i = startIdx, endIdx do
-					table.insert(chunk, ARGV[i])
-				end
-				redis.call('RPUSH', KEYS[1], unpack(chunk))
-				startIdx = endIdx + 1
+		while startIdx <= lastEventIdx do
+			local endIdx = math.min(startIdx + chunkSize - 1, lastEventIdx)
+			local chunk = {}
+			for i = startIdx, endIdx do
+				table.insert(chunk, ARGV[i])
 			end
+			redis.call('RPUSH', KEYS[1], unpack(chunk))
+			startIdx = endIdx + 1
+		end
 
-			if statusEnabled then
-				local aggID = ARGV[lastEventIdx + 1]
-				local newStatus = ARGV[lastEventIdx + 2]
-				local statusSetPrefix = KEYS[statusKey] .. ":"
-				local oldStatus = redis.call('HGET', KEYS[statusKey], aggID) or ""
-				if oldStatus ~= "" and oldStatus ~= newStatus then
-					redis.call('SREM', statusSetPrefix .. oldStatus, aggID)
-				end
-				if newStatus ~= "" then
-					redis.call('SADD', statusSetPrefix .. newStatus, aggID)
-					redis.call('HSET', KEYS[statusKey], aggID, newStatus)
-				else
-					redis.call('HDEL', KEYS[statusKey], aggID)
-				end
+		if statusEnabled then
+			local aggID = ARGV[lastEventIdx + 1]
+			local newStatus = ARGV[lastEventIdx + 2]
+			local statusSetPrefix = KEYS[2] .. ":"
+			local oldStatus = redis.call('HGET', KEYS[2], aggID) or ""
+			if oldStatus ~= "" and oldStatus ~= newStatus then
+				redis.call('SREM', statusSetPrefix .. oldStatus, aggID)
+			end
+			if newStatus ~= "" then
+				redis.call('SADD', statusSetPrefix .. newStatus, aggID)
+				redis.call('HSET', KEYS[2], aggID, newStatus)
+			else
+				redis.call('HDEL', KEYS[2], aggID)
 			end
 		end
 		`
@@ -42,8 +40,8 @@ const (
 	luaAppendEventsTrim = `
 		-- Atomically append events to list with sequence consistency check
 		-- KEYS[1] = event list key
-		-- KEYS[2] = snapshot sequence key
-		-- KEYS[3] = status hash key (optional)
+		-- KEYS[2] = status hash key (empty string when disabled)
+		-- KEYS[3] = snapshot sequence key
 		-- ARGV[1] = expected sequence (global)
 		-- ARGV[2..N] = event data (JSON), followed by aggregate ID and status
 		--                when status projection is enabled
@@ -51,7 +49,7 @@ const (
 
 		local currentLen = redis.call('LLEN', KEYS[1])
 		local expected = tonumber(ARGV[1])
-		local offset = tonumber(redis.call('GET', KEYS[2]) or "0")
+		local offset = tonumber(redis.call('GET', KEYS[3]) or "0")
 		local currentSeq = offset + currentLen
 
 		if expected ~= currentSeq then
@@ -66,8 +64,7 @@ const (
 			return {0, currentSeq, {}}
 		end
 
-		` + _appendAndProjectStatus + `
-		appendAndProjectStatus(2, 3)
+		` + _appendAndProjectStatus_ + `
 
 		return {1, offset + redis.call('LLEN', KEYS[1])}
 		`
@@ -132,7 +129,7 @@ const (
 	luaAppendEvents = `
 		-- Atomically append events to list with sequence consistency check
 		-- KEYS[1] = event list key
-		-- KEYS[2] = status hash key (optional)
+		-- KEYS[2] = status hash key (empty string when disabled)
 		-- ARGV[1] = expected sequence (current list length)
 		-- ARGV[2..N] = event data (JSON), followed by aggregate ID and status
 		--                when status projection is enabled
@@ -149,8 +146,7 @@ const (
 			return {0, currentLen, {}}
 		end
 
-		` + _appendAndProjectStatus + `
-		appendAndProjectStatus(1, 2)
+		` + _appendAndProjectStatus_ + `
 
 		return {1, redis.call('LLEN', KEYS[1])}
 		`

--- a/store.go
+++ b/store.go
@@ -157,13 +157,14 @@ func (s *Store) AppendEvents(
 	}
 
 	eventsKey := s.buildKey(id, eventsSuffix)
-	keys := []string{eventsKey}
+	statusKey := ""
+	if status != nil {
+		statusKey = s.buildGlobalKey(statusSuffix)
+	}
+	keys := []string{eventsKey, statusKey}
 	if s.config.TrimEvents {
 		snapSeqKey := s.buildKey(id, snapshotSeqSuffix)
-		keys = []string{eventsKey, snapSeqKey}
-	}
-	if status != nil {
-		keys = append(keys, s.buildGlobalKey(statusSuffix))
+		keys = append(keys, snapSeqKey)
 	}
 	args := []any{atSeq}
 


### PR DESCRIPTION
### Motivation

- Ensure the Redis Lua scripts correctly handle an optional global status projection key by passing an explicit placeholder when projection is disabled, avoiding positional key mismatches.

### Description

- Changed the Lua snippet to determine `statusEnabled` from `KEYS[2]` being non-empty and consistently reference the status hash at `KEYS[2]` and the snapshot sequence at `KEYS[3]` for the trimmed scripts.
- Inlined and renamed the append-and-project snippet to `_appendAndProjectStatus_` and updated its logic to use the fixed key positions and preserve chunked `RPUSH` behavior.
- Updated comments in Lua scripts to document that `KEYS[2]` may be an empty string when status projection is disabled and that `KEYS[3]` is the snapshot sequence key in trim mode.
- Modified `AppendEvents` key construction in `store.go` to always include a `statusKey` placeholder (empty string when disabled) as the second key and append the snapshot sequence key afterwards when `TrimEvents` is enabled, so the Lua scripts receive keys in the expected order.

### Testing

- Ran unit tests with `go test ./...` and they succeeded.
